### PR TITLE
Sticter clippy: report warnings as errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           tool: nextest
       - name: Run cargo clippy
         run: |
-          cargo clippy
+          cargo clippy --all-targets -- -D warnings
       - name: Run cargo nextest
         run: |
           cargo nextest run --profile ci --all-features


### PR DESCRIPTION
This should make the CI report clippy warnings as errors